### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   ],
   "description": "Import Metadata for Images in Project",
   "docker_image": "supervisely/import-export:6.73.564",
-  "min_instance_version": "6.11.8",
+  "instance_version": "6.15.60",
   "main_script": "src/import_metadata.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "metadata"
   ],
   "description": "Import Metadata for Images in Project",
-  "docker_image": "supervisely/import-export:6.73.162",
+  "docker_image": "supervisely/import-export:6.73.564",
   "min_instance_version": "6.11.8",
   "main_script": "src/import_metadata.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "metadata"
   ],
   "description": "Import Metadata for Images in Project",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/import_metadata.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.162
+supervisely==6.73.564

--- a/src/import_metadata.py
+++ b/src/import_metadata.py
@@ -1,8 +1,8 @@
 import os
 import tarfile
 
-import supervisely_lib as sly
-from supervisely_lib.io.json import load_json_file
+import supervisely as sly
+from supervisely.io.json import load_json_file
 
 my_app = sly.AppService()
 


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
